### PR TITLE
example - migrate with new `States{Builder|Listener}`

### DIFF
--- a/example/counter/pubspec.lock
+++ b/example/counter/pubspec.lock
@@ -42,7 +42,7 @@ packages:
       name: dart_scope
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.0-alpha.7"
+    version: "0.1.0-beta.2"
   disposal:
     dependency: transitive
     description:

--- a/example/todo/lib/flutter/add_todo_page.dart
+++ b/example/todo/lib/flutter/add_todo_page.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_scope/flutter_scope.dart';
 
 import '../dart/add_todo_notifier.dart';
-import '../dart/todo.dart';
 
 class AddTodoPage extends StatelessWidget {
   const AddTodoPage({super.key});
@@ -35,8 +34,10 @@ class AddTodoView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final addTodoNotifier = context.scope.get<AddTodoNotifier>();
-    return StatesListenerConvert<AddTodoState, Todo?>(
-      convert: (state) => state.todoSubmitted,
+    final addTodoStates = context.scope.getStates<AddTodoState>();
+    return StatesListener(
+      states: addTodoStates
+        .convert((state) => state.todoSubmitted),
       onData: (context, todoSubmitted) {
         Navigator.pop(context, todoSubmitted);
       },
@@ -53,8 +54,9 @@ class AddTodoView extends StatelessWidget {
             ),
           ),
         ),
-        floatingActionButton: StatesBuilderConvert<AddTodoState, bool>(
-          convert: (state) => state.isTodoTitleValid,
+        floatingActionButton: StatesBuilder(
+          states: addTodoStates
+            .convert((state) => state.isTodoTitleValid),
           builder: (context, isTodoTitleValid)  => FloatingActionButton(
             onPressed: isTodoTitleValid 
               ? addTodoNotifier.onTodoSubmitted 

--- a/example/todo/lib/flutter/my_app.dart
+++ b/example/todo/lib/flutter/my_app.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_scope/flutter_scope.dart';
-import '../dart/item_changed.dart';
 import '../dart/todos_notifier.dart';
 import '../dart/todo.dart';
 import '../dart/todo_filter_notifier.dart';
@@ -35,7 +34,7 @@ class AppScope extends FlutterScope {
       ),
       FinalStates<List<Todo>>(
         equal: (scope) => filteredTodosStates(
-          todosStates: scope.get<States<TodosState>>()
+          todosStates: scope.getStates<TodosState>()
             .convert((state) => state.todos.values.toList()),
           filterStates: scope.get(),
         ),
@@ -69,8 +68,9 @@ class TodoChangesListener extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return StatesListenerConvert<TodosState, ItemChanges<String, Todo>>(
-      convert: (state) => state.changes,
+    return StatesListener(
+      states: context.scope.getStates<TodosState>()
+        .convert((state) => state.changes),
       onData: (context, changes) {
         final text = [
           if (changes.inserts.isNotEmpty) '${changes.inserts.length} todo(s) inserted',

--- a/example/todo/lib/flutter/todos_page.dart
+++ b/example/todo/lib/flutter/todos_page.dart
@@ -61,8 +61,8 @@ class TodosView extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Todo'),
         actions: [
-          StatesBuilder<TodoFilter>.statesEqual(
-            statesEqual: (_) => todoFilterStates,
+          StatesBuilder(
+            states: todoFilterStates,
             builder: (context, filter) {
               return TodoFilterButton(
                 filter: filter,
@@ -72,8 +72,8 @@ class TodosView extends StatelessWidget {
           )
         ],
       ),
-      body: StatesBuilder<List<Todo>>.statesEqual(
-        statesEqual: (_) => todosStates,
+      body: StatesBuilder(
+        states: todosStates,
         builder: (context, todos) => Stack(
           fit: StackFit.expand,
           children: [

--- a/example/todo/pubspec.lock
+++ b/example/todo/pubspec.lock
@@ -84,7 +84,7 @@ packages:
       name: dart_scope
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.0-alpha.7"
+    version: "0.1.0-beta.2"
   disposal:
     dependency: transitive
     description:

--- a/example/todo/test/flutter/todos_page_test.dart
+++ b/example/todo/test/flutter/todos_page_test.dart
@@ -165,7 +165,7 @@ void main() {
             ),
             FinalStates<List<Todo>>(
               equal: (scope) => filteredTodosStates(
-                todosStates: scope.get<States<TodosState>>()
+                todosStates: scope.getStates<TodosState>()
                   .convert((state) => state.todos.values.toList()),
                 filterStates: scope.get(),
               ),


### PR DESCRIPTION
subtask of #57 