### PR TITLE
refactor - add `StatesBuilder` child parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,7 +572,7 @@ FlutterScope(
     ),
   ],
   child: StatesBuilder<TodoFilter>(
-    builder: (context, todoFilter) {
+    builder: (context, todoFilter, child) {
       return ...; // map state to widget
     },
   ),
@@ -625,7 +625,7 @@ FlutterScope(
           states2: context.scope.getStates<TodoFilter>(),
           compute: filterTodos,
         ),
-        builder: (context, filteredTodos) {
+        builder: (context, filteredTodos, child) {
           return ...; // map state to widget
         },
       );

--- a/example/README.md
+++ b/example/README.md
@@ -78,7 +78,7 @@ class CounterView extends StatelessWidget {
             ),
             // Convert counter state to UI, as: UI = f(state)
             StatesBuilder<CounterState>(
-              builder: (context, count) => Text(
+              builder: (context, count, child) => Text(
                 '$count',
                 style: Theme.of(context).textTheme.headline4,
               ),

--- a/example/counter/lib/main.dart
+++ b/example/counter/lib/main.dart
@@ -68,7 +68,7 @@ class CounterView extends StatelessWidget {
             ),
             // Convert counter state to UI, as: UI = f(state)
             StatesBuilder<CounterState>(
-              builder: (context, count) => Text(
+              builder: (context, count, _) => Text(
                 '$count',
                 style: Theme.of(context).textTheme.headline4,
               ),

--- a/example/counter/pubspec.lock
+++ b/example/counter/pubspec.lock
@@ -42,7 +42,7 @@ packages:
       name: dart_scope
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.0-beta.2"
+    version: "0.1.0-beta.3"
   disposal:
     dependency: transitive
     description:
@@ -75,7 +75,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.1.0-alpha.2"
+    version: "0.1.0-beta.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/example/todo/lib/flutter/add_todo_page.dart
+++ b/example/todo/lib/flutter/add_todo_page.dart
@@ -57,7 +57,7 @@ class AddTodoView extends StatelessWidget {
         floatingActionButton: StatesBuilder(
           states: addTodoStates
             .convert((state) => state.isTodoTitleValid),
-          builder: (context, isTodoTitleValid)  => FloatingActionButton(
+          builder: (context, isTodoTitleValid, _)  => FloatingActionButton(
             onPressed: isTodoTitleValid 
               ? addTodoNotifier.onTodoSubmitted 
               : null,

--- a/example/todo/lib/flutter/todos_page.dart
+++ b/example/todo/lib/flutter/todos_page.dart
@@ -63,7 +63,7 @@ class TodosView extends StatelessWidget {
         actions: [
           StatesBuilder(
             states: todoFilterStates,
-            builder: (context, filter) {
+            builder: (context, filter, _) {
               return TodoFilterButton(
                 filter: filter,
                 onSelected: onTodoFilterChanged,
@@ -74,7 +74,7 @@ class TodosView extends StatelessWidget {
       ),
       body: StatesBuilder(
         states: todosStates,
-        builder: (context, todos) => Stack(
+        builder: (context, todos, _) => Stack(
           fit: StackFit.expand,
           children: [
             if (todos.isEmpty) Center(

--- a/lib/src/states_widgets.dart
+++ b/lib/src/states_widgets.dart
@@ -93,8 +93,8 @@ abstract class StatesWidgetBaseState<W extends StatesWidgetBase<T>, T>
   }
 }
 
-/// A `Builder` build a widget with a state.
-typedef StateWidgetBuilder<T> = Widget Function(BuildContext context, T state);
+/// A `Builder` build a widget with a state and an optional child.
+typedef StateWidgetBuilder<T> = Widget Function(BuildContext context, T state, Widget? child);
 
 /// `StatesBuilder` transform a sequence of state to widget.
 class StatesBuilder<T> extends StatesWidgetBase<T> {
@@ -109,7 +109,7 @@ class StatesBuilder<T> extends StatesWidgetBase<T> {
   ///     ),
   ///   ],
   ///   child: StatesBuilder<TodoFilter>(
-  ///     builder: (context, todoFilter) {
+  ///     builder: (context, todoFilter, child) {
   ///       return ...; // map state to widget
   ///     },
   ///   ),
@@ -141,9 +141,13 @@ class StatesBuilder<T> extends StatesWidgetBase<T> {
     super.hotReloadKey,
     super.states,
     required this.builder,
+    this.child,
   });
 
+  /// A `builder` return widget based on current state.
   final StateWidgetBuilder<T> builder;
+  /// An optional child been used to remove unnecessary rebuild.
+  final Widget? child;
 
   @override
   createState() => _StatesBuilderState<T>();
@@ -163,7 +167,7 @@ class _StatesBuilderState<T> extends StatesWidgetBaseState<StatesBuilder<T>, T> 
   @override
   Widget build(BuildContext context) {
     assert(_currentState is T, 'Current state: $_currentState, should be instance of $T at build stage.');
-    return widget.builder(context, _currentState as T);
+    return widget.builder(context, _currentState as T, widget.child);
   }
 }
 

--- a/test/flutter_scope/states_widget_test.dart
+++ b/test/flutter_scope/states_widget_test.dart
@@ -481,52 +481,28 @@ void main() {
       StatesBuilder<String>(
         states: variable.asStates(),
         builder: (context, state, child) {
-          return Builder(
-            builder: (context) {
-              invokes.add('builder as builder parameter');
-              return Container();
-            },
-          ); 
-        },
-      ),
-    );
-    expect(invokes, [
-      'builder as builder parameter',
-    ]);
-
-    variable.value = 'b';
-    await tester.pump();
-    expect(invokes, [
-      'builder as builder parameter',
-      'builder as builder parameter',
-    ]);
-
-    await tester.pumpWidget(
-      StatesBuilder<String>(
-        states: variable.asStates(),
-        builder: (context, state, child) {
+          invokes.add('builder builds');
           return child!;
         },
         child: Builder(
           builder: (context) {
-            invokes.add('builder as child parameter');
+            invokes.add('child builds');
             return Container();
           },
         ),
       ),
     );
     expect(invokes, [
-      'builder as builder parameter',
-      'builder as builder parameter',
-      'builder as child parameter',
+      'builder builds',
+      'child builds',
     ]);
 
-    variable.value = 'c';
+    variable.value = 'b';
     await tester.pump();
     expect(invokes, [
-      'builder as builder parameter',
-      'builder as builder parameter',
-      'builder as child parameter',
+      'builder builds',
+      'child builds',
+      'builder builds',
     ]);
 
     variable.dispose();

--- a/test/flutter_scope/states_widget_test.dart
+++ b/test/flutter_scope/states_widget_test.dart
@@ -219,7 +219,7 @@ void main() {
     await tester.pumpWidget(
       StatesBuilder<String>(
         states: variable.asStates(),
-        builder: (context, state) {
+        builder: (context, state, _) {
           recorded.add(state);
           return Container(); 
         },
@@ -254,7 +254,7 @@ void main() {
           Final<States<String>>(equal: (_) => variable.asStates()),
         ],
         child: StatesBuilder<String>(
-          builder: (context, state) {
+          builder: (context, state, _) {
             recorded.add(state);
             return Container();
           },
@@ -282,7 +282,7 @@ void main() {
 
     await tester.pumpWidget(
       StatesBuilder<String>(
-        builder: (context, state) => Container(),
+        builder: (context, state, _) => Container(),
       ),
     );
 
@@ -304,7 +304,7 @@ void main() {
       FlutterScope(
         configure: const [],
         child: StatesBuilder<String>(
-          builder: (context, state) => Container(),
+          builder: (context, state, _) => Container(),
         ),
       ),
     );
@@ -337,7 +337,7 @@ void main() {
     await tester.pumpWidget(
       StatesBuilder<String>(
         states: states,
-        builder: (context, state) => Container(),
+        builder: (context, state, _) => Container(),
       ),
     );
     expect(invokes, [
@@ -384,7 +384,7 @@ void main() {
     await tester.pumpWidget(
       StatesBuilder<String>(
         states: states,
-        builder: (context, state) => Container(),
+        builder: (context, state, _) => Container(),
       ),
     );
     expect(invokes, [
@@ -394,7 +394,7 @@ void main() {
     await tester.pumpWidget(
       StatesBuilder<String>(
         states: similarStates, // use similar states
-        builder: (context, state) => Container(),
+        builder: (context, state, _) => Container(),
       )
     );
     expect(invokes, [
@@ -404,7 +404,7 @@ void main() {
     await tester.pumpWidget(
       StatesBuilder<String>(
         states: changedStates,
-        builder: (context, state) => Container(),
+        builder: (context, state, _) => Container(),
       ),
     );
     expect(invokes, [
@@ -439,7 +439,7 @@ void main() {
     await tester.pumpWidget(
       StatesBuilder<String>(
         states: states,
-        builder: (context, state) => Container(),
+        builder: (context, state, _) => Container(),
       ),
     );
     expect(invokes, [
@@ -449,7 +449,7 @@ void main() {
     await tester.pumpWidget(
       StatesBuilder<String>(
         states: similarStates, // use similar states
-        builder: (context, state) => Container(),
+        builder: (context, state, _) => Container(),
       ),
     );
     expect(invokes, [
@@ -460,7 +460,7 @@ void main() {
       StatesBuilder<String>(
         hotReloadKey: 1,
         states: similarStates,
-        builder: (context, state) => Container(),
+        builder: (context, state, _) => Container(),
       ),
     );
     expect(invokes, [
@@ -471,6 +471,67 @@ void main() {
 
   });
 
+  testWidgets('StatesBuilder optimize build with child parameter', (tester) async {
+
+    final List<String> invokes = [];
+
+    final variable = Variable('a');
+
+    await tester.pumpWidget(
+      StatesBuilder<String>(
+        states: variable.asStates(),
+        builder: (context, state, child) {
+          return Builder(
+            builder: (context) {
+              invokes.add('builder as builder parameter');
+              return Container();
+            },
+          ); 
+        },
+      ),
+    );
+    expect(invokes, [
+      'builder as builder parameter',
+    ]);
+
+    variable.value = 'b';
+    await tester.pump();
+    expect(invokes, [
+      'builder as builder parameter',
+      'builder as builder parameter',
+    ]);
+
+    await tester.pumpWidget(
+      StatesBuilder<String>(
+        states: variable.asStates(),
+        builder: (context, state, child) {
+          return child!;
+        },
+        child: Builder(
+          builder: (context) {
+            invokes.add('builder as child parameter');
+            return Container();
+          },
+        ),
+      ),
+    );
+    expect(invokes, [
+      'builder as builder parameter',
+      'builder as builder parameter',
+      'builder as child parameter',
+    ]);
+
+    variable.value = 'c';
+    await tester.pump();
+    expect(invokes, [
+      'builder as builder parameter',
+      'builder as builder parameter',
+      'builder as child parameter',
+    ]);
+
+    variable.dispose();
+
+  });
 
   testWidgets('StatesListener assigned states directly', (tester) async {
 


### PR DESCRIPTION
## Why

Add a `child` parameter to `StatesBuilder`:

```diff
StatesBuilder<String>(
  states: ...,
  builder: (context, state, child) {
    return ....;
  },
+ child: ..., // add child parameter
)
```

This `child` parameter will remove unnecessary rebuild to child in following situation:
  1. `child` widget don't depend on `state`
  2. `states` emit a new state

Example demostrate the situation:

```dart
  testWidgets('StatesBuilder optimize build with child parameter', (tester) async {

    final List<String> invokes = [];
    final variable = Variable('a'); // `Variable` is similar to `StreamController`

    await tester.pumpWidget(
      StatesBuilder<String>(
        states: variable.asStates(),
        builder: (context, state, child) {
          invokes.add('builder builds'); // record `builder builds`
          return child!;
        },
        // child widget don't depend on `state`
        child: Builder(
          builder: (context) {
            invokes.add('child builds'); // record `child builds`
            return Container();
          },
        ),
      ),
    );
    expect(invokes, [
      'builder builds',
      'child builds',
    ]);

    // emit a new state, trigger rebuild
    variable.value = 'b';
    await tester.pump();
    expect(invokes, [
      'builder builds',
      'child builds',
      'builder builds',
      //'child builds', // unnecessary child rebuild is removed here
    ]);

    variable.dispose();

  });
``` 

## How to migrate?

1. if `child` widget depend on `state`, we only need to ignore child parameter:

    ```diff
    StatesBuilder(
    - builder: (context, state) {
    + builder: (context, state, _) { 
        return ...; // map state to widget
      },
    )
    ```

3. If `child` widget don't depend on `state`, we need to pass it to child parameter:
    
    Before:
    
    ```dart
    StatesBilder<String>(
      builder: (context, state) {
        return MyWidget(
          value: state,
          child: Builder(...),
        ),
      },
    )
    ```
    
    After:
    
    ```dart
    StatesBilder<String>(
      builder: (context, state, child) {
        return MyWidget(
          value: state,
          child: child!,
        ),
      },
      child: Builder(...), // pass it to child parameter
    )
    ```

This API change also aligned with [ValueListenableBuilder](https://api.flutter.dev/flutter/widgets/ValueListenableBuilder-class.html).